### PR TITLE
Deep freeze hash values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+ - "1.9.3"
+ - "2.2.3"
+script: ruby test/test.rb

--- a/lib/hierarchical_config.rb
+++ b/lib/hierarchical_config.rb
@@ -134,6 +134,7 @@ module HierarchicalConfig
         when value.respond_to?( :keys ) && value.respond_to?( :values )
           child_hash, child_errors = lock_down_and_ostructify!( value, path + '.' + key, environment )
           errors += child_errors
+          child_hash.each { |key, value| value.freeze }
           hash[key] = OpenStruct.new(child_hash).freeze
         when value == REQUIRED
           errors << "#{path}.#{key} is REQUIRED for #{environment}"

--- a/test/test.rb
+++ b/test/test.rb
@@ -50,8 +50,15 @@ end
 begin
   one_config.something = 'goodbye'
   assert( false, 'attempts to modify config after load should raise a TypeError' )
-rescue TypeError => t
+rescue TypeError, RuntimeError => t
   # this is good
+end
+
+begin
+  one_config.tree1.tree2 << 'hey'
+  assert( false, 'error should be raised' )
+rescue StandardError => e
+  assert( e.to_s =~ /can't modify frozen String/, 'Should receive error about modifying frozen string')
 end
 
 two_config = HierarchicalConfig.load_config( 'two', TEST_CONFIG_DIR, 'test' )


### PR DESCRIPTION
Found a bug where I was able to modify the contents of a nested config value. 2.2.3 raises a `RuntimeError` instead of a `TypeError` when you attempt to modify a frozen string. Added travis support to make sure I wasn't breaking anything in ruby 1.9.3 in case you're still using it.