### PR TITLE
Document that props ending in ? are disallowed, fix allcaps keys

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Metrics/MethodLength:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
       sorbet-static (= 0.5.10689)
     sorbet-runtime (0.5.10689)
     sorbet-static (0.5.10689-universal-darwin-22)
+    sorbet-static (0.5.10689-x86_64-linux)
     sorbet-static-and-runtime (0.5.10689)
       sorbet (= 0.5.10689)
       sorbet-runtime (= 0.5.10689)
@@ -120,6 +121,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bundler

--- a/lib/hierarchical_config.rb
+++ b/lib/hierarchical_config.rb
@@ -25,10 +25,14 @@ module HierarchicalConfig
     end
 
     sig do
-      params(blk: T.nilable(T.proc.
-               params(name: T.untyped, value: T.untyped).
-               returns([T.untyped, T.untyped]))).
-        returns(T::Hash[T.untyped, T.untyped])
+      type_parameters(:A, :B)
+        .params(
+          blk: T.nilable(
+            T.proc.params(name: Symbol, value: T.untyped)
+             .returns([T.type_parameter(:A), T.type_parameter(:B)])
+          )
+        )
+        .returns(T::Hash[T.any(Symbol, T.type_parameter(:A)), T.type_parameter(:B)])
     end
     def to_h(&blk)
       hash = to_hash

--- a/lib/hierarchical_config.rb
+++ b/lib/hierarchical_config.rb
@@ -71,7 +71,7 @@ module HierarchicalConfig
     def build_types(current_item, name, parent_class)
       case current_item
       when Hash
-        new_type_name = ActiveSupport::Inflector.camelize(ActiveSupport::Inflector.underscore(name))
+        new_type_name = inflect_typename(name)
 
         return Hash if current_item.keys.to_a.any?{|k| k =~ /^[0-9]/ || k =~ /[- ]/}
 
@@ -115,7 +115,7 @@ module HierarchicalConfig
       when Hash
         return current_item.symbolize_keys if current_item.keys.to_a.any?{|k| k =~ /^[0-9]/ || k =~ /[- ]/}
 
-        current_type = parent_class.const_get(ActiveSupport::Inflector.camelize(name))
+        current_type = parent_class.const_get(inflect_typename(name))
         current_type.new(Hash[current_item.map{|key, value| [key.to_sym, build_config(value, key, current_type)]}]) # rubocop:disable Style/HashConversion
       when Array
         current_item.each_with_index.map do |item, index|
@@ -246,6 +246,11 @@ module HierarchicalConfig
         end
       end
       hash1
+    end
+
+    sig{params(name: String).returns(String)}
+    def inflect_typename(name)
+      ActiveSupport::Inflector.camelize(name)
     end
   end
 end

--- a/lib/hierarchical_config.rb
+++ b/lib/hierarchical_config.rb
@@ -25,14 +25,17 @@ module HierarchicalConfig
     end
 
     sig do
-      type_parameters(:A, :B)
-        .params(
+      type_parameters(:A, :B).
+        params(
           blk: T.nilable(
-            T.proc.params(name: Symbol, value: T.untyped)
-             .returns([T.type_parameter(:A), T.type_parameter(:B)])
-          )
-        )
-        .returns(T::Hash[T.any(Symbol, T.type_parameter(:A)), T.type_parameter(:B)])
+            T.proc.params(name: Symbol, value: T.untyped).
+             returns([T.type_parameter(:A), T.type_parameter(:B)]),
+          ),
+        ).
+        returns(T.any(
+          T::Hash[T.type_parameter(:A), T.type_parameter(:B)],
+          T::Hash[Symbol, T.untyped],
+        ))
     end
     def to_h(&blk)
       hash = to_hash

--- a/lib/hierarchical_config.rb
+++ b/lib/hierarchical_config.rb
@@ -24,6 +24,21 @@ module HierarchicalConfig
       Hash[self.class.props.keys.map{|key| [key, item_to_hash(send(key))]}] # rubocop:disable Style/HashConversion
     end
 
+    sig do
+      params(blk: T.nilable(T.proc.
+               params(name: T.untyped, value: T.untyped).
+               returns([T.untyped, T.untyped]))).
+        returns(T::Hash[T.untyped, T.untyped])
+    end
+    def to_h(&blk)
+      hash = to_hash
+      if blk
+        hash.to_h(&blk)
+      else
+        hash.to_h
+      end
+    end
+
     sig{params(key: T.any(String, Symbol)).returns(T.untyped)}
     def [](key)
       send(key)

--- a/spec/config/one.yml
+++ b/spec/config/one.yml
@@ -16,6 +16,31 @@ defaults:
     - one
     - two
     - three
+  strangekey_hash_of_arrays:
+    ALLCAPSZERO:
+      - arr0: true
+        arr1: one
+    ALLCAPSONE:
+      - arr0: false
+        arr2: two
+    ALL_CAPS_TWO:
+      - arr0: true
+        arr3: three
+    CamelCase:
+      - arr0: false
+        arr4: four
+    dromedaryCase:
+      - arr0: true
+        arr5: five
+    snake_case:
+      - arr0: false
+        arr6: six
+    Camel_Snake:
+      - arr0: true
+        arr7: seven
+    dromedary_Snake:
+      - arr0: false
+        arr8: eight
 
 defaults[test,cucumber,development]:
   cache_classes: false

--- a/spec/config/prop_ending_with_question_mark.yml
+++ b/spec/config/prop_ending_with_question_mark.yml
@@ -1,0 +1,2 @@
+defaults:
+  does_this_work?: false

--- a/spec/config/two.yml
+++ b/spec/config/two.yml
@@ -16,6 +16,31 @@ defaults:
     - one
     - two
     - three
+  strangekey_hash_of_arrays:
+    ALLCAPSZERO:
+      - arr0: true
+        arr1: one
+    ALLCAPSONE:
+      - arr0: false
+        arr2: two
+    ALL_CAPS_TWO:
+      - arr0: true
+        arr3: three
+    CamelCase:
+      - arr0: false
+        arr4: four
+    dromedaryCase:
+      - arr0: true
+        arr5: five
+    snake_case:
+      - arr0: false
+        arr6: six
+    Camel_Snake:
+      - arr0: true
+        arr7: seven
+    dromedary_Snake:
+      - arr0: false
+        arr8: eight
 
 defaults[test,cucumber,development]:
   cache_classes: false

--- a/spec/hierarchical_config_spec.rb
+++ b/spec/hierarchical_config_spec.rb
@@ -111,6 +111,58 @@ RSpec.describe HierarchicalConfig do
           )
         end
       end
+
+      context 'with to_h' do # rubocop:disable RSpec/NestedGroups
+        it 'supports to_h without block' do # rubocop:disable RSpec/ExampleLength
+          expect(config.to_h).to eq(
+            one: 'one',
+            two: 'two',
+            three: 'three',
+            cache_classes: false,
+            something: 'hello',
+            tree1: {
+              tree2: 'hey',
+              tree3: {tree4: 'bleh'},
+            },
+            array_of_hashes: [
+              {key1: 'value1a', key2: 'value2a'},
+              {key1: 'value1b', key2: 'value2b'},
+            ],
+            array_of_strings: %w[one two three],
+            strangekey_hash_of_arrays: {
+              ALLCAPSZERO: [
+                {arr0: true, arr1: 'one'},
+              ],
+              ALLCAPSONE: [
+                {arr0: false, arr2: 'two'},
+              ],
+              ALL_CAPS_TWO: [
+                {arr0: true, arr3: 'three'},
+              ],
+              CamelCase: [
+                {arr0: false, arr4: 'four'},
+              ],
+              dromedaryCase: [
+                {arr0: true, arr5: 'five'},
+              ],
+              snake_case: [
+                {arr0: false, arr6: 'six'},
+              ],
+              Camel_Snake: [
+                {arr0: true, arr7: 'seven'},
+              ],
+              dromedary_Snake: [
+                {arr0: false, arr8: 'eight'},
+              ],
+            },
+          )
+        end
+
+        it 'supports to_h with block' do
+          result = config.to_h{|n, v| [n.to_s, v]}
+          expect(result['one']).to eq('one')
+        end
+      end
     end
 
     context 'when in production environment' do

--- a/spec/hierarchical_config_spec.rb
+++ b/spec/hierarchical_config_spec.rb
@@ -82,6 +82,32 @@ RSpec.describe HierarchicalConfig do
               {key1: 'value1b', key2: 'value2b'},
             ],
             array_of_strings: %w[one two three],
+            strangekey_hash_of_arrays: {
+              ALLCAPSZERO: [
+                {arr0: true, arr1: 'one'},
+              ],
+              ALLCAPSONE: [
+                {arr0: false, arr2: 'two'},
+              ],
+              ALL_CAPS_TWO: [
+                {arr0: true, arr3: 'three'},
+              ],
+              CamelCase: [
+                {arr0: false, arr4: 'four'},
+              ],
+              dromedaryCase: [
+                {arr0: true, arr5: 'five'},
+              ],
+              snake_case: [
+                {arr0: false, arr6: 'six'},
+              ],
+              Camel_Snake: [
+                {arr0: true, arr7: 'seven'},
+              ],
+              dromedary_Snake: [
+                {arr0: false, arr8: 'eight'},
+              ],
+            },
           )
         end
       end
@@ -109,6 +135,14 @@ RSpec.describe HierarchicalConfig do
 
     it 'supports ERB and exposes an error' do
       expect{config}.to raise_error(/Error loading config from file.*boom/)
+    end
+  end
+
+  context 'with prop_ending_with_question_mark.yml' do
+    let(:file){'prop_ending_with_question_mark'}
+
+    it 'raises the invalid property error from sorbet' do
+      expect{config}.to raise_error(ArgumentError, /Invalid prop name in HierarchicalConfig/)
     end
   end
 


### PR DESCRIPTION
I came across some issues when attempting to upgrade an application which used some properties ending in `?` (which seems to run afoul of newer sorbet rules), as well as a problem with maps with all-caps keys. The spec changes in this PR should demonstrate the bug if viewed in isolation. I also added a bunch more cases to the spec, not all of which were necessarily failing at any point but which we may want to ensure will work regardless.